### PR TITLE
Add a *very* simple unit test suite

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(tests LANGUAGES CXX)
+
+add_executable(tests RangingDeviceTests.cpp)

--- a/tests/RangingDeviceTests.cpp
+++ b/tests/RangingDeviceTests.cpp
@@ -1,0 +1,66 @@
+#include <cstdint>
+#include <cassert>
+#include <iostream>
+
+class RangingDevice {
+public:
+	RangingDevice(int32_t inactivityThreshold, int32_t (*millis)(void)) {
+		_millis = millis;
+		_activity = 0;
+		_inactivityThreshold = inactivityThreshold;
+	}
+
+	void noteActivity() {
+		_activity = _millis();
+	}
+
+	bool isInactive() {
+		bool isInactive =  _millis() - _activity > _inactivityThreshold;
+		if (isInactive) {
+			noteActivity();
+		}
+		return isInactive;
+	}
+private:
+	int32_t _activity;
+	int32_t _inactivityThreshold;
+	int32_t (*_millis)(void);
+};
+
+int32_t currentTimestamp = 0;
+
+int32_t millis() {
+	return currentTimestamp;
+}
+
+void testActivityIsNotInvalidatedWhenLessThanThreshold() {
+	RangingDevice test(1000, millis);
+	test.noteActivity();
+	assert(!test.isInactive());
+}
+
+void testActivityIsInactiveWhenPastTimerThreshold() {
+	RangingDevice test(1000, millis);
+	test.noteActivity();
+	currentTimestamp = 1001;
+	assert(test.isInactive());
+}
+
+void testIsInactiveRenotesActivityWhenInactive() {
+	RangingDevice test(1000, millis);
+	test.noteActivity();
+	currentTimestamp = 1001;
+	test.isInactive(); // NB: This should have a side-effect which renotes the activity
+	assert(!test.isInactive());
+}
+
+int main(void) {
+	currentTimestamp = 0;
+	testActivityIsNotInvalidatedWhenLessThanThreshold();
+	currentTimestamp = 0;
+	testActivityIsInactiveWhenPastTimerThreshold();
+	currentTimestamp = 0;
+	testIsInactiveRenotesActivityWhenInactive();
+	std::cout << "Tests Passed" << std::endl;
+	return 0;
+}


### PR DESCRIPTION
This PR adds a very simple test suite which tests 2 methods on a deterministic version of `DW1000Device` that I simply called `RangingDevice`. There's no fancy unit testing framework here atm, just plain asserts.

Overall, the goal of adding unit tests here would be:
1. We can run parts of the codebase on our local development machines with no additional hardware required (which is why it was fine to use things like iostream).
2. We can get fast feedback on the state of our code (working or not working) and quality of our designs.
3. Testing very small nuances or edge cases that may be hard to reproduce in tests involving actual hardware.

Of course, this is not a substitute for testing on the actual hardware (as their may be obvious differences in environment, and unit test should still take those into account if possible), but in reality most of the code here is portable outside of a few blocks which call into arduino functions.

In these cases, it's still possible to unit test the main logic via mocking, which is what I've done here. The `DW1000Device` class uses the `millis` function which isn't deterministic and thus is hard to unit test reliably. So I simply made the new `RangingDevice` class hold onto a function pointer which would behave like the `millis` function, and then stubbed a deterministic version in for tests so that we could test all scenarios in inactivity.

I'll leave this as draft for now if we want to change the testing setup.